### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You need to create a `settings.json` file matching the following structure:
 	"username": "XXX",
 	"password": "YYY",
 	"dbfile": "/path/to/database/avabur.db",
-	"csvdir": "/path/to/final/csv/files"
+	"csvdir": "/path/to/final/csv/files",
+	"marketdir": "/path/to/final/market/files"
 }
 ```
 


### PR DESCRIPTION
rendermarket.py references `settings['marketdir']` which is not in the `settings.json` snippet.